### PR TITLE
Unified syntax, cleanup, minor bug fixes

### DIFF
--- a/m4a_hq_mixer.s
+++ b/m4a_hq_mixer.s
@@ -118,6 +118,7 @@
     .equ    BDPCM_BLK_SIZE_SHIFT, 0x6
 
     .thumb
+    .thumb_func
     .align  2
 
 SoundMainRAM:
@@ -1002,6 +1003,7 @@ C_mixing_epilogue:
     BX      R0
 
     .thumb
+    .thumb_func
 
 C_end_channel_state_loop:
     LDR     R0, [SP, #ARG_REMAIN_CHN]
@@ -1123,6 +1125,7 @@ C_downsampler_loop:
 
     .align  1
     .thumb
+    .thumb_func
 
 C_downsampler_return:
     LDR     R0, [SP, #ARG_PCM_STRUCT]

--- a/m4a_hq_mixer.s
+++ b/m4a_hq_mixer.s
@@ -860,10 +860,9 @@ C_setup_fixed_freq_mixing:
     STMFD   SP!, {R4, R9}
 
 C_fixed_mixing_length_check:
-    MOV     LR, R2                          @ sample countdown
-    CMP     R2, R8
-    MOVGT   LR, R8                          @ min(buffer_size, sample_countdown)
-    SUB     LR, LR, #1
+    CMP     R2, R8                          @ min(buffer_size, sample_countdown) - 1
+    SUBGT   LR, R8, #1
+    SUBLE   LR, R2, #1
     MOVS    LR, LR, LSR#2
     BEQ     C_fixed_mixing_process_rest     @ <= 3 samples to process
 

--- a/m4a_hq_mixer.s
+++ b/m4a_hq_mixer.s
@@ -1069,7 +1069,8 @@ C_downsampler_return:
     MOV     R9, R1
     MOV     R10, R2
     MOV     R11, R3
-    POP     {PC}
+    POP     {R3}
+    BX      R3                                  @ Interwork
 
     .pool
 


### PR DESCRIPTION
Changes
 - Convert to unified syntax so it can be compiled with both binutils and clang
   - I didn't change `MOV X, Y, LSL#N` and the like to `LSL X, Y, #N`.
 - Replace most copy/pasted blocks with `.rept` and `.irp`
   - Needed one minor tweak 
 - Some comments
 - Save one instruction by changing `min(x, y) - 1` to `min(x - 1, y - 1)`
 - Waste one instruction by interworking to be safe

I intentionally didn't fix #8 because I don't know the correct answer.