### PR TITLE
Allocate buffer for mixer itself in IWRAM

### DIFF
--- a/m4a_hq_mixer.s
+++ b/m4a_hq_mixer.s
@@ -1190,3 +1190,17 @@ C_clear_loop_rest:
     SUBS    R1, R1, #4
     BGT     C_clear_loop_rest
     POP     {R0, R2-R5, PC}
+
+MixerEnd:
+
+    .equ    MIXER_BUFFER_SIZE, MixerEnd - SoundMainRAM
+
+    .global MixerSize
+MixerSize:
+    .int MIXER_BUFFER_SIZE
+
+    .bss
+
+    .global MixerBuffer
+MixerBuffer:
+    .space MIXER_BUFFER_SIZE


### PR DESCRIPTION
Code size is calculated automatically.

# Usage

Header file:
```C
extern u8 MixerBuffer[];
extern int MixerSize;
```
Source file:
```C
CpuCopy32(((void *) (((iptr) SoundMainRAM) & ~1)), MixerBuffer, MixerSize);
```
Linker script:
```
. = FreeIWRAMSpace;
.iwram : { m4a_hq_mixer.*(.bss) }
```

From: https://github.com/laqieer/FEHRR/commit/0f3ca3f2e34ad551e0bc42a20e8e6bab045fa270